### PR TITLE
Enable "--includes" option at reading configuration.

### DIFF
--- a/yagist.el
+++ b/yagist.el
@@ -264,7 +264,7 @@ should both be strings."
 
 (defun yagist-read-config (key)
   (let ((val (yagist-command-to-string
-              "config" "--global" (format "github.%s" key))))
+              "config" "--global" "--includes" (format "github.%s" key))))
     (cond
      ((string-match "\\`[\n]*\\'" val) nil)
      ((string-match "\n+\\'" val)


### PR DESCRIPTION
For configurations in another config file by include.path.
(I put github.token and github.oauth-token in another config file.)

For information about "--includes" option, see the following URL.
http://git-scm.com/docs/git-config#_includes
