### PR TITLE
Change revert-buffer-function to buffer local variable.

### DIFF
--- a/yagist.el
+++ b/yagist.el
@@ -42,7 +42,7 @@
 ;; If you want to save encrypted token to ~/.gitconfig download following url.
 ;;
 ;; https://github.com/mhayashi1120/Emacs-cipher/raw/master/cipher/aes.el
-;; 
+;;
 ;; (setq yagist-encrypt-risky-config t)
 
 ;;; TODO:
@@ -133,7 +133,8 @@ Example:
   "Show your gist list"
   (setq buffer-read-only t)
   (setq truncate-lines t)
-  (setq revert-buffer-function 'yagist-list-revert-buffer)
+  (set (make-local-variable 'revert-buffer-function)
+       'yagist-list-revert-buffer)
   (add-hook 'post-command-hook 'yagist-list--paging-retrieve nil t)
   (use-local-map yagist-list-mode-map))
 


### PR DESCRIPTION
Change revert-buffer-function from global variable to to buffer local
variable in yagist-list-mode. IF revert-buffer-function is global
variable, `revert-buffer` function is called in any other buffer each
time yagist-list-revert-buffer is called too in any other buffer.

Step to reproduce:
1. M-x yagist-list
2. switch to any other buffer (e.g _scratch_)
3. M-x revert-buffer 
