### PR TITLE
read github.token variable from gitconfig

### DIFF
--- a/yagist.el
+++ b/yagist.el
@@ -165,6 +165,7 @@ Example:
 (defun yagist-check-oauth-token ()
   (cond
    ((or yagist-github-token
+        (yagist-config "token")
         (yagist-config "oauth-token")))
    (t
     (let* ((user (or yagist-github-user


### PR DESCRIPTION
Many tools use `github.config` variable.
