### PR TITLE
Github now uses a 32 vs 20 sized hash.

### DIFF
--- a/yagist.el
+++ b/yagist.el
@@ -622,7 +622,7 @@ for the gist."
     (cond
      ;; check redirected location indicate public/private gist url
      ((and (stringp location)
-           (string-match "\\([0-9]+\\|[0-9a-zA-Z]\\{20\\}\\)$" location))
+           (string-match "\\([0-9]+\\|[0-9a-zA-Z]\\{32\\}\\)$" location))
       (let ((id (match-string 1 location)))
         (setq http-url (format "https://gist.github.com/%s" id))
         (message "Paste created: %s" http-url)


### PR DESCRIPTION
The 20 size will yield urls that are 404s. You need 32 instead of 20 chars of the hash.
